### PR TITLE
Extend auction filtering

### DIFF
--- a/backend/src/main/java/com/example/backend/controller/AuctionController.java
+++ b/backend/src/main/java/com/example/backend/controller/AuctionController.java
@@ -35,16 +35,19 @@ public class AuctionController {
     }
 
     @GetMapping
-    public ResponseEntity<?> findAllFilteredAuctions(@RequestParam(required = false) List<String> statuses,
-                                                     @RequestParam Boolean myAuctions,
-                                                     @RequestParam Boolean followed,
-                                                     @RequestParam(required = false) List<String> dates) {
+    public ResponseEntity<?> findAllFilteredAuctions(
+            @RequestParam(required = false) List<String> statuses,
+            @RequestParam Boolean myAuctions,
+            @RequestParam Boolean followed,
+            @RequestParam(required = false) List<String> dates,
+            @RequestParam(required = false) String sortBy
+    ) {
         try {
             String userEmail = SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString();
 
             statuses = Objects.requireNonNullElse(statuses, List.of());
             dates = Objects.requireNonNullElse(dates, List.of());
-            return ResponseEntity.ok(auctionService.getFilteredAuctions(statuses, myAuctions, followed, dates, userEmail));
+            return ResponseEntity.ok(auctionService.getFilteredAuctions(statuses, myAuctions, followed, dates, sortBy, userEmail));
         } catch (IOException e) {
             return ResponseEntity.status(500).body("Error while retrieving filtered auctions: " + e.getMessage());
         }

--- a/backend/src/main/java/com/example/backend/gviz/AuctionQueryBuilder.java
+++ b/backend/src/main/java/com/example/backend/gviz/AuctionQueryBuilder.java
@@ -102,18 +102,6 @@ public class AuctionQueryBuilder {
         return this;
     }
 
-    public AuctionQueryBuilder withSorting(String sortBy) {
-        if ("priceAsc".equalsIgnoreCase(sortBy)) {
-            builder.orderBy(Column.CURRENT_BID.label, true);
-        } else if ("priceDesc".equalsIgnoreCase(sortBy)) {
-            builder.orderBy(Column.CURRENT_BID.label, false);
-        }
-
-        builder.orderBy(Column.PUBLIC_ID.label, true);
-
-        return this;
-    }
-
     public String build() {
         return builder.build();
     }

--- a/backend/src/main/java/com/example/backend/gviz/AuctionQueryBuilder.java
+++ b/backend/src/main/java/com/example/backend/gviz/AuctionQueryBuilder.java
@@ -42,24 +42,34 @@ public class AuctionQueryBuilder {
         if (statuses.contains("NO_DATE")) {
             builder.whereIsNull(Column.AUCTION_DATE.label);
         }
-
-        if (statuses.contains("APPROVED")) {
-            builder.whereIsNotNull(Column.AUCTION_DATE.label);
-        }
-
         if (statuses.contains("INCOMPLETE")) {
-            List<String> requiredFields = List.of(
+            builder.whereAnyIsNull(List.of(
                     Column.TITLE.label,
                     Column.DESCRIPTION.label,
                     Column.AUCTION_DATE.label,
                     Column.IMAGE_URL.label,
                     Column.STARTING_PRICE.label
-            );
-            builder.whereAnyIsNull(requiredFields);
+            ));
         }
-
+        if (statuses.contains("NO_MODERATOR")) {
+            builder.whereIsNull(Column.MODERATOR_EMAIL.label);
+        }
+        if (statuses.contains("NO_BID")) {
+            builder.whereIsNull(Column.CURRENT_BID.label);
+        }
+        if (statuses.contains("COMPLETE")) {
+            builder.whereAllNotNull(List.of(
+                    Column.TITLE.label,
+                    Column.DESCRIPTION.label,
+                    Column.AUCTION_DATE.label,
+                    Column.IMAGE_URL.label,
+                    Column.STARTING_PRICE.label,
+                    Column.CURRENT_BID.label
+            ));
+        }
         return this;
     }
+
 
     public AuctionQueryBuilder withSupplier(String email) {
         if (email != null) {
@@ -88,6 +98,19 @@ public class AuctionQueryBuilder {
     public AuctionQueryBuilder onlyFollowersById(UUID auctionId) {
         builder.select(Column.FOLLOWERS.label);
         builder.whereEquals(Column.ID.label, auctionId.toString());
+
+        return this;
+    }
+
+    public AuctionQueryBuilder withSorting(String sortBy) {
+        if ("priceAsc".equalsIgnoreCase(sortBy)) {
+            builder.orderBy(Column.CURRENT_BID.label, true);
+        } else if ("priceDesc".equalsIgnoreCase(sortBy)) {
+            builder.orderBy(Column.CURRENT_BID.label, false);
+        }
+
+        builder.orderBy(Column.PUBLIC_ID.label, true);
+
         return this;
     }
 

--- a/backend/src/main/java/com/example/backend/gviz/GvizQueryBuilder.java
+++ b/backend/src/main/java/com/example/backend/gviz/GvizQueryBuilder.java
@@ -8,6 +8,7 @@ public class GvizQueryBuilder {
     private final Map<String, String> columnLetterMap;
     private final List<String> conditions = new ArrayList<>();
     private final List<String> selectedColumns = new ArrayList<>();
+    private final List<String> orderings = new ArrayList<>();
 
     public GvizQueryBuilder(Map<String, String> columnLetterMap) {
         this.columnLetterMap = columnLetterMap;
@@ -54,6 +55,20 @@ public class GvizQueryBuilder {
         return this;
     }
 
+    public GvizQueryBuilder whereAllNotNull(List<String> columnNames) {
+        if (columnNames == null || columnNames.isEmpty()) return this;
+
+        String andCondition = columnNames.stream()
+                .map(columnLetterMap::get)
+                .map(column -> column + " IS NOT NULL")
+                .reduce((a, b) -> a + " AND " + b)
+                .map(condition -> "(" + condition + ")")
+                .orElse("");
+
+        conditions.add(andCondition);
+        return this;
+    }
+
     public GvizQueryBuilder whereDateEqualsAnyOf(String columnName, List<String> dates) {
         if (dates == null || dates.isEmpty()) return this;
 
@@ -68,9 +83,17 @@ public class GvizQueryBuilder {
         return this;
     }
 
+    public GvizQueryBuilder orderBy(String columnName, boolean ascending) {
+        String columnLetter = columnLetterMap.get(columnName);
+        String order = columnLetter + (ascending ? " ASC" : " DESC");
+        orderings.add(order);
+        return this;
+    }
+
     public String build() {
         String selectClause = "SELECT " + String.join(", ", selectedColumns);
         String whereClause = conditions.isEmpty() ? "" : " WHERE " + String.join(" AND ", conditions);
-        return selectClause + whereClause;
+        String orderClause = orderings.isEmpty() ? "" : " ORDER BY " + String.join(", ", orderings);
+        return selectClause + whereClause + orderClause;
     }
 }

--- a/backend/src/main/java/com/example/backend/repository/AuctionRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/AuctionRepository.java
@@ -12,7 +12,7 @@ public interface AuctionRepository {
     void save(Auction auction) throws IOException;
     void update(UUID auctionId, Auction auction) throws IOException;
     Auction findByAuctionId(UUID auctionId) throws IOException;
-    List<Auction> findAllByFiltersAndUser(List<String> statuses, Boolean myAuctions, Boolean followed, List<String> dates, String userEmail) throws IOException;
+    List<Auction> findAllByFiltersAndUser(List<String> statuses, Boolean myAuctions, Boolean followed, List<String> dates, String sortBy, String userEmail) throws IOException;
     void follow(UUID auctionId, String userEmail) throws IOException;
     void unfollow(UUID auctionId, String userEmail) throws IOException;
 }

--- a/backend/src/main/java/com/example/backend/repository/GoogleSheetsAuctionRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/GoogleSheetsAuctionRepository.java
@@ -4,6 +4,7 @@ import com.example.backend.gviz.AuctionQueryBuilder;
 import com.example.backend.model.Auction;
 import com.example.backend.service.GoogleSheetsHeaderMappingService;
 import com.example.backend.service.GoogleSheetsService;
+import com.example.backend.util.AuctionSorter;
 import com.example.backend.util.CreateRowInGoogleSheets;
 import com.example.backend.gviz.GvizResponseParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -68,7 +69,6 @@ public class GoogleSheetsAuctionRepository implements AuctionRepository {
         return gvizResponseParser.parseAuctionsResponse(response).get(0);
     }
 
-
     @Override
     public List<Auction> findAllByFiltersAndUser(List<String> statuses, Boolean myAuctions, Boolean followed, List<String> dates, String sortBy, String userEmail) throws IOException {
         String queryWithFilters = new AuctionQueryBuilder(headerMappingService)
@@ -77,13 +77,12 @@ public class GoogleSheetsAuctionRepository implements AuctionRepository {
                 .withDates(dates)
                 .withSupplier(myAuctions ? userEmail : null)
                 .withFollowed(followed ? userEmail : null)
-                .withSorting(sortBy)
                 .build();
 
         String response = googleSheetsService.queryWithGviz(queryWithFilters, "Auction");
-        return gvizResponseParser.parseAuctionsResponse(response);
+        List<Auction> auctions = gvizResponseParser.parseAuctionsResponse(response);
+        return AuctionSorter.sortAuctions(auctions, sortBy);
     }
-
 
     private List<String> findFollowersByAuctionId(UUID auctionId) throws IOException {
         String query = new AuctionQueryBuilder(headerMappingService)

--- a/backend/src/main/java/com/example/backend/repository/GoogleSheetsAuctionRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/GoogleSheetsAuctionRepository.java
@@ -70,13 +70,14 @@ public class GoogleSheetsAuctionRepository implements AuctionRepository {
 
 
     @Override
-    public List<Auction> findAllByFiltersAndUser(List<String> statuses, Boolean myAuctions, Boolean followed, List<String> dates, String userEmail) throws IOException {
+    public List<Auction> findAllByFiltersAndUser(List<String> statuses, Boolean myAuctions, Boolean followed, List<String> dates, String sortBy, String userEmail) throws IOException {
         String queryWithFilters = new AuctionQueryBuilder(headerMappingService)
                 .selectAllColumns()
                 .withStatuses(statuses)
                 .withDates(dates)
                 .withSupplier(myAuctions ? userEmail : null)
                 .withFollowed(followed ? userEmail : null)
+                .withSorting(sortBy)
                 .build();
 
         String response = googleSheetsService.queryWithGviz(queryWithFilters, "Auction");

--- a/backend/src/main/java/com/example/backend/service/AuctionService.java
+++ b/backend/src/main/java/com/example/backend/service/AuctionService.java
@@ -35,8 +35,8 @@ public class AuctionService {
         return auctionRepository.findByAuctionId(auctionId);
     }
 
-    public List<AuctionGetDto> getFilteredAuctions(List<String> statuses, boolean myAuctions, boolean followed, List<String> dates, String userEmail) throws IOException {
-        List<Auction> auctions = auctionRepository.findAllByFiltersAndUser(statuses, myAuctions, followed, dates, userEmail);
+    public List<AuctionGetDto> getFilteredAuctions(List<String> statuses, boolean myAuctions, boolean followed, List<String> dates, String sortBy, String userEmail) throws IOException {
+        List<Auction> auctions = auctionRepository.findAllByFiltersAndUser(statuses, myAuctions, followed, dates, sortBy, userEmail);
 
         return auctions.stream().map(auction -> auctionMapper.mapToGetDto(auction, userEmail)).toList();
     }

--- a/backend/src/main/java/com/example/backend/util/AuctionSorter.java
+++ b/backend/src/main/java/com/example/backend/util/AuctionSorter.java
@@ -1,0 +1,56 @@
+package com.example.backend.util;
+
+import com.example.backend.model.Auction;
+
+import java.util.List;
+
+public class AuctionSorter {
+    public static List<Auction> sortAuctions(List<Auction> auctions, String sortBy) {
+        return auctions.stream()
+                .sorted((auctionA, auctionB) -> {
+                    boolean sortByPriceAscending = "priceAsc".equalsIgnoreCase(sortBy);
+                    boolean sortByPriceDescending = "priceDesc".equalsIgnoreCase(sortBy);
+
+                    if (!sortByPriceAscending && !sortByPriceDescending) {
+                        return compareByPublicId(auctionA, auctionB);
+                    }
+
+                    Double valueOfAuctionA = auctionA.getCurrentBid() != null
+                            ? auctionA.getCurrentBid()
+                            : auctionA.getStartingPrice();
+
+                    Double valueOfAuctionB = auctionB.getCurrentBid() != null
+                            ? auctionB.getCurrentBid()
+                            : auctionB.getStartingPrice();
+
+                    boolean auctionAHasPrice = valueOfAuctionA != null;
+                    boolean auctionBHasPrice = valueOfAuctionB != null;
+
+                    if (auctionAHasPrice && !auctionBHasPrice) return -1;
+                    if (!auctionAHasPrice && auctionBHasPrice) return 1;
+                    if (!auctionAHasPrice && !auctionBHasPrice) {
+                        return compareByPublicId(auctionA, auctionB);
+                    }
+
+                    int priceComparison = sortByPriceAscending
+                            ? Double.compare(valueOfAuctionA, valueOfAuctionB)
+                            : Double.compare(valueOfAuctionB, valueOfAuctionA);
+
+                    return priceComparison != 0
+                            ? priceComparison
+                            : compareByPublicId(auctionA, auctionB);
+                })
+                .toList();
+    }
+
+    private static int compareByPublicId(Auction auctionA, Auction auctionB) {
+        Long publicIdA = auctionA.getPublicId();
+        Long publicIdB = auctionB.getPublicId();
+
+        if (publicIdA == null && publicIdB == null) return 0;
+        if (publicIdA == null) return 1;
+        if (publicIdB == null) return -1;
+
+        return publicIdA.compareTo(publicIdB);
+    }
+}

--- a/frontend/src/components/AuctionPage/Filters.tsx
+++ b/frontend/src/components/AuctionPage/Filters.tsx
@@ -32,8 +32,14 @@ const statusValueMap: Record<string, string> = {
     "Niekompletne": "INCOMPLETE",
     "Bez moderatora": "NO_MODERATOR",
     "Bez daty": "NO_DATE",
-    "Bez oferty": "NO_OFFER",
+    "Bez oferty": "NO_BID",
     "Kompletne": "COMPLETE",
+};
+
+const sortValueMap: Record<string, string | null> = {
+    "Domyślne": null,
+    "Cena: od najniższej": "priceAsc",
+    "Cena: od najwyższej": "priceDesc",
 };
 
 const dateValueMap: Record<string, string> = {
@@ -70,6 +76,13 @@ const Filters = ({aucfilters, setAucFilters}: FiltersProps) => {
         }));
     }, [selectedDates]);
 
+    useEffect(() => {
+        setAucFilters(prev => ({
+            ...prev,
+            sortBy: sortValueMap[sort] || undefined,
+        }));
+    }, [sort]);
+
     const isAnySelected =
         selectedStatuses.length > 0 ||
         selectedTypes.length > 0 ||
@@ -79,6 +92,7 @@ const Filters = ({aucfilters, setAucFilters}: FiltersProps) => {
         setSelectedStatuses([]);
         setSelectedTypes([]);
         setSelectedDates([]);
+        setSort("Domyślne");
     };
 
     return (

--- a/frontend/src/services/fetchAuctions.ts
+++ b/frontend/src/services/fetchAuctions.ts
@@ -6,6 +6,7 @@ export interface AuctionFilters {
     myAuctions?: boolean;
     followed?: boolean;
     dates?: string[];
+    sortBy?: string;
 }
 
 export const fetchAuctions = async (filters: AuctionFilters): Promise<Auction[]> => {


### PR DESCRIPTION
**`priceAsc` / `priceDesc`**:
- Sort by `currentBid` if present, otherwise by `startingPrice` (ascending / descending)
- Auctions with neither are placed last
- Ties are resolved using the **default** strategy (by `publicId`, ascending)

**Default**:
- Sort by `publicId` (ascending)
- Auctions with `null` `publicId` go **last**